### PR TITLE
change AfricaIOC headless setting

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -31,7 +31,7 @@ sources:
   url: https://ioc-africa.org/sitemap.xml
   changefreq: daily
   backend: Custom  
-  headless: true
+  headless: false
   dateadded: 2023-02-09
   active: true
 #


### PR DESCRIPTION
- to match the current sitemap (which points to raw JSON-LD, without `<body>` tags)  : https://ioc-africa.org/dbs/jsonld/researchVessels.php?id=1