### PR TITLE
config: fix EurOcean & OceanExpert entries

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -151,58 +151,7 @@ sources:
   backend: SeaDataCloud
   dateadded: 2021-07-26
   headless: false
-  active: true
-#
-# EurOcean Events
-#    
-- name: euroceanevents
-  propername: EurOcean Events
-  domain: https://infohub.eurocean.net/
-  catalogue: https://infohub.eurocean.net/data/events
-  logo: https://infohub.eurocean.net/images/under_constrution/eurOcean-logo-color.png  
-  #ODISCat entry missing ODIS-arch url & type
-  pid: https://catalogue.odis.org/view/2993  
-  sourcetype: sitemap  
-  url: https://www.oceanexpert.org/assets/sitemaps/sitemapEvents.xml
-  changefreq: unknown
-  backend: unknown    
-  headless: false
-  dateadded: 2022-03-26
-  active: true  
-#
-# EurOcean Experts
-#   
-- name: euroceanexperts
-  propername: EurOcean Experts
-  domain: https://infohub.eurocean.net/
-  catalogue: https://infohub.eurocean.net/data/experts
-  logo: https://infohub.eurocean.net/images/under_constrution/eurOcean-logo-color.png  
-  #ODISCat entry missing ODIS-arch url & type
-  pid: https://catalogue.odis.org/view/2993
-  sourcetype: sitemap
-  url: https://www.oceanexpert.org/assets/sitemaps/sitemapExperts.xml
-  changefreq: unknown  
-  backend: unknown  
-  headless: false
-  dateadded: 2022-03-26
-  active: true
-#
-# EurOcean Institutions
-#   
-- name: euroceaninstitutions
-  propername: EurOcean Institutions
-  domain: https://infohub.eurocean.net/
-  catalogue: https://infohub.eurocean.net/data/institutions  
-  logo: https://infohub.eurocean.net/images/under_constrution/eurOcean-logo-color.png  
-  #ODISCat entry missing ODIS-arch url & type
-  pid: https://catalogue.odis.org/view/2993
-  sourcetype: sitemap  
-  url: https://www.oceanexpert.org/assets/sitemaps/sitemapInstitutions.xml
-  changefreq: unknown  
-  backend: unknown  
-  headless: false
-  dateadded: 2022-03-26  
-  active: true
+  active: true 
 #
 # EurOcean Organizations
 #   
@@ -239,23 +188,6 @@ sources:
   headless: false
   dateadded: 2022-03-26 
   active: true
-#
-# EurOcean Training
-#    
-- name: euroceantraining
-  propername: EurOcean Training 
-  domain: https://infohub.eurocean.net/
-  catalogue: https://infohub.eurocean.net/data/training 
-  logo: https://infohub.eurocean.net/images/under_constrution/eurOcean-logo-color.png  
-  #ODISCat entry missing ODIS-arch url & type
-  pid: https://catalogue.odis.org/view/2993  
-  sourcetype: sitemap
-  url: https://www.oceanexpert.org/assets/sitemaps/sitemapTraining.xml
-  changefreq: unknown  
-  backend: unknown  
-  headless: false
-  dateadded: 2022-03-26  
-  active: true  
 #
 # EurOcean Vessels
 #    
@@ -474,7 +406,7 @@ sources:
   backend: unknown  
   headless: false
   dateadded: 2021-08-26  
-  active: true  
+  active: true
 #
 # Oceanscape Project
 # 


### PR DESCRIPTION
- caught by Doug in #149 
- I was mixing up EurOcean and OceanExpert endpoints (bizarre, but it happened)
- the actual issue is that the main OceanExpert sitemap index is empty, I believe: index: https://oceanexpert.org/assets/sitemaps/sitemapIndex.xml (so that's what #149 will track)
- this pull request removes those odd entries, and leaves the one main entry for OceanExpert (that points to the sitemap index)
- also will follow-up with EurOcean team