### PR TITLE
add countryOfOrigin to Vessels pattern

### DIFF
--- a/book/thematics/vessels/graphs/ship.json
+++ b/book/thematics/vessels/graphs/ship.json
@@ -12,6 +12,10 @@
         "url": "https://example.org/id/vessel/X",
         "description": "Vessel ID "
     },
+    "countryOfOrigin": {
+        "@type": "Country",
+        "name": "Fiji"
+    },    
     "additionalProperty": {
         "@id": "ID_value_string",
         "@type": "PropertyValue",


### PR DESCRIPTION
- front-end OIH search will leverage the `countryOfOrigin` property from the schema.org `Vehicle` type, for Vessels