### PR TITLE
add Address property into Experts pattern

### DIFF
--- a/book/thematics/expinst/graphs/person.json
+++ b/book/thematics/expinst/graphs/person.json
@@ -6,6 +6,7 @@
   "@type": "Person",
   "name": "Jane Doe",
   "jobTitle": "Professor",
+  "address": "54 Ocean Drive, 23521 Ocean City, CountryName",
   "telephone": "(425) 123-4567",
   "url": "http://www.janedoe.com",
   "knowsAbout": [
@@ -44,7 +45,7 @@
       "termCode": "FJ"
     }
   ],
-  "knowsLanguage" :{
+  "knowsLanguage": {
     "@type": "Language",
     "name": "Spanish",
     "alternateName": "es"


### PR DESCRIPTION
- front-end OIH search will leverage the `address` property from the schema.org `Person` type, for Experts
- important: the current indexer code assumes that the address property is text (not the `"@type": "PostalAddress"`)
- here is a proper example:
  - `"address": "54 Ocean Drive, 23521 Ocean City, CountryName"`
- cc @arnounesco 