### PR TITLE
point to missing Dataset JSON file in book

### DIFF
--- a/book/thematics/dataset/index.md
+++ b/book/thematics/dataset/index.md
@@ -34,7 +34,7 @@ of [schema.org/CreativeWork](https://schema.org/CreativeWork) and then provide e
 for more focused creative work examples.
 
 
-```{literalinclude} ./graphs/obisData.json
+```{literalinclude} ./graphs/datasetTemplate.json
 :linenos:
 ```
 


### PR DESCRIPTION
- this fixes the issue of the Dataset section of the book missing an example JSON (empty)
- this was caused through https://github.com/iodepo/odis-arch/pull/130