### PR TITLE
add countryOfLastProcessing for Vessels

### DIFF
--- a/book/thematics/vessels/graphs/ship.json
+++ b/book/thematics/vessels/graphs/ship.json
@@ -12,10 +12,11 @@
         "url": "https://example.org/id/vessel/X",
         "description": "Vessel ID "
     },
+    "countryOfLastProcessing": "Angola",
     "countryOfOrigin": {
         "@type": "Country",
         "name": "Fiji"
-    },    
+    },
     "additionalProperty": {
         "@id": "ID_value_string",
         "@type": "PropertyValue",


### PR DESCRIPTION
- this example matches what was implemented by the IOC Africa node, in consultation with the OIH team (IOC Africa node is where most of the vessel records come from)