### PR TITLE
[FIX TEXT][Publisher and Provider]

### DIFF
--- a/book/thematics/docs/README.md
+++ b/book/thematics/docs/README.md
@@ -113,8 +113,9 @@ jbutils.show_graph(framed)
 
 ### Publisher and provider
 
-Our JSON-LD documents are graphs that can use framing to subset.  In this 
-case we can look closer at the author property which points to a type Person. 
+Our JSON-LD documents are graphs that can use framing to subset.  In this case
+we can look closer at the `provider` and `publisher` properties, which are both 
+of type `Organization`. 
 
 
 ```{code-cell}


### PR DESCRIPTION
@jmckenna

## Issue
Wrong text for [Publisher and Provider](https://book.oceaninfohub.org/thematics/docs/README.html#publisher-and-provider)

file: `/book/thematics/docs/README.md`

## Solution
from ```... author property which points to a type Person.``` 
to ```...`provider` and `publisher` properties, which are both of type `Organization`.```

