### PR TITLE
clarify vessels definition

### DIFF
--- a/book/thematics/expinst/README.md
+++ b/book/thematics/expinst/README.md
@@ -29,7 +29,7 @@ In this case the following definitions are used:
 The following graph present a basic record we might use for a person.  
 We will break down some of the key properties used in this graph.
 
-As Ocean InfoHub is levergaing Schema.org we are 
+As Ocean InfoHub is leveraging Schema.org we are 
 using [schema.org/Person](https://schema.org/Person) for this type.
 Any of the properties of Person seen there are valid to use in such a record.
 

--- a/book/thematics/vessels/README.md
+++ b/book/thematics/vessels/README.md
@@ -23,7 +23,8 @@ like research vessel is not well aligned to current types.
 For vessels in OIH, we leverage the existing Schema.org type [Vehicle](https://schema.org/Vehicle) 
 which is described as a device that is designed or used to transport people 
 or cargo over land, water, air, or through space; 
-but we additionally define vessels as *all operations at sea* to cover any research vessel.  
+but we additionally define vessels as *all operations at sea* to cover any vessel on the ocean, 
+such as a fishing boat.  
 We could go on to connect this type then to a descriptive property in a concept such as
 the WikiData entry for [Research Vessel, Q391022](https://www.wikidata.org/wiki/Q391022).
 We may also wish to leverage some of the approaches in [Keywords and Defined Terms](../terms/list.md).

--- a/book/thematics/vessels/README.md
+++ b/book/thematics/vessels/README.md
@@ -20,13 +20,13 @@ OIH is exploring how we might leverage schema.org to describe research vessels.
 Note that schema.org is a very broad vocabulary and as such specific concepts 
 like research vessel is not well aligned to current types.
 
-In Schema.org the type [Vehicle](https://schema.org/Vehicle) is described as a device that is designed 
-or used to transport people or cargo over land, water, air, or through space.
-We have used this broad scoping to cover research vessels.  We could go on to 
-connect this type then to a descriptive property in a concept such as
+For vessels in OIH, we leverage the existing Schema.org type [Vehicle](https://schema.org/Vehicle) 
+which is described as a device that is designed or used to transport people 
+or cargo over land, water, air, or through space; 
+but we additionally define vessels as *all operations at sea* to cover any research vessel.  
+We could go on to connect this type then to a descriptive property in a concept such as
 the WikiData entry for [Research Vessel, Q391022](https://www.wikidata.org/wiki/Q391022).
 We may also wish to leverage some of the approaches in [Keywords and Defined Terms](../terms/list.md).
-
 
 Our goal is to use schema.org as a simple upper level vocabulary that allows
 us to describe research vessels in a simple manner and then connect to more 

--- a/code/notebooks/Exploration/dashboard/dashboard.py
+++ b/code/notebooks/Exploration/dashboard/dashboard.py
@@ -114,7 +114,7 @@ with st.expander("OIH Graph Endpoint Status", expanded=True):
 
         os.chdir(dashboardPath)
 
-        @st.cache_data(ttl=3600)
+        #@st.cache_data(ttl=3600)
         def get_sparql_dataframe(service, query):
             """
             Helper function to convert SPARQL results into a Pandas data frame.
@@ -323,6 +323,8 @@ if graphStatus == 1:
         """,
         unsafe_allow_html=True,
         )
+        
+        st.toast("The Dashboard performs heavy SPARQL queries to the ODIS graph :hourglass:")
         
         sumCol1, sumCol2, sumCol3 = st.columns(3, gap="medium")
 


### PR DESCRIPTION
- explains how a "fishing boat" fits into the `vessels` pattern
- also fixes minor spelling mistake in the `Experts and Institutions` pattern

related to #278